### PR TITLE
Fix CMP0054 warnings in CMake >= 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ include(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
 include(CheckCXXSourceCompiles)
 
 # Default compiler args
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|.*Clang)")
+if (CMAKE_CXX_COMPILER_ID MATCHES "(GNU|.*Clang)")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Werror -Wall -Wextra -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=sign-compare -std=c++11")
 	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 	set(CMAKE_CXX_FLAGS_MINSIZEREL "-g -Os -DNDEBUG")
 	set(CMAKE_CXX_FLAGS_RELEASE "-g -O2 -DNDEBUG")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL 'MSVC')
 	# /Zi - Produces a program database (PDB) that contains type information and symbolic debugging information for use with the debugger.
 	# /FS - Allows multiple cl.exe processes to write to the same .pdb file
 	# /DEBUG - Enable debug during linking
@@ -42,7 +42,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Ox /Zi /FS /DEBUG")
 endif()
 
-# if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+# if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 #     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -Wno-c++98-compat -Wno-shadow -Wno-padded -Wno-missing-noreturn -Wno-global-constructors")
 # endif()
 
@@ -56,7 +56,7 @@ set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 include(CheckCXX11Features.cmake)
 
 set(OLD_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ((MAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 check_cxx_source_compiles(
@@ -132,7 +132,6 @@ if (ENTITYX_BUILD_SHARED)
         )
     set_target_properties(entityx_shared PROPERTIES
         OUTPUT_NAME entityx
-        DEBUG_POSTFIX -d
         VERSION ${ENTITYX_VERSION}
         SOVERSION ${ENTITYX_MAJOR_VERSION})
     list(APPEND install_libs entityx_shared)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if (ENTITYX_BUILD_SHARED)
         )
     set_target_properties(entityx_shared PROPERTIES
         OUTPUT_NAME entityx
+        DEBUG_POSTFIX -d
         VERSION ${ENTITYX_VERSION}
         SOVERSION ${ENTITYX_MAJOR_VERSION})
     list(APPEND install_libs entityx_shared)


### PR DESCRIPTION
Single quote use of literal 'MSVC'.
Remove use of quoted variables inside if and elseif blocks.
